### PR TITLE
feat: add network detail inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ unifi events list --limit 50                # Last 50 events
 ```bash
 unifi networks list                         # List all networks
 unifi networks                              # Same thing
+unifi networks show IoT                     # DHCP, DNS, mDNS, and cellular-backup details
 ```
 
 ### System

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -445,6 +445,20 @@ impl UnifiClient {
         .await
     }
 
+    pub async fn get_network_detail(&self, identifier: &str) -> Result<LegacyNetwork, ApiError> {
+        let networks: Vec<LegacyNetwork> = self.get_legacy("/rest/networkconf").await?;
+        networks
+            .into_iter()
+            .find(|network| {
+                network.id == identifier
+                    || network
+                        .name
+                        .as_deref()
+                        .is_some_and(|name| name.eq_ignore_ascii_case(identifier))
+            })
+            .ok_or_else(|| ApiError::NotFound(format!("Network not found: {identifier}")))
+    }
+
     // Events
     //
     // Legacy `stat/event` was removed in UniFi Network 9+ (UniFi OS) and now

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -165,6 +165,31 @@ pub struct Network {
     pub default: bool,
 }
 
+/// Network configuration from the legacy `rest/networkconf` endpoint.
+///
+/// Keep this deliberately typed: network configuration records can grow new,
+/// sensitive fields over time and commands must never serialize the raw object.
+#[derive(Debug, Deserialize)]
+pub struct LegacyNetwork {
+    #[serde(rename = "_id")]
+    pub id: String,
+    pub name: Option<String>,
+    pub purpose: Option<String>,
+    pub vlan: Option<u16>,
+    pub ip_subnet: Option<String>,
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub dhcpd_enabled: bool,
+    #[serde(default)]
+    pub dhcpd_dns_enabled: bool,
+    pub dhcpd_dns_1: Option<String>,
+    pub dhcpd_dns_2: Option<String>,
+    #[serde(default)]
+    pub mdns_enabled: bool,
+    pub lte_lan_enabled: Option<bool>,
+}
+
 // Health subsystem from Legacy stat/health
 #[derive(Debug, Deserialize)]
 pub struct HealthSubsystem {

--- a/src/commands/networks.rs
+++ b/src/commands/networks.rs
@@ -65,3 +65,91 @@ pub async fn list(
     out.print_message(&format!("\n{} networks", networks.len()));
     Ok(())
 }
+
+pub async fn show(
+    client: &UnifiClient,
+    identifier: &str,
+    out: OutputConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let network = client.get_network_detail(identifier).await?;
+    let dns_servers: Vec<&str> = [
+        network.dhcpd_dns_1.as_deref(),
+        network.dhcpd_dns_2.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    .filter(|server| !server.is_empty())
+    .collect();
+
+    let record = serde_json::json!({
+        "id": network.id,
+        "name": network.name,
+        "purpose": network.purpose,
+        "vlan_id": network.vlan,
+        "subnet": network.ip_subnet,
+        "enabled": network.enabled,
+        "dhcp_enabled": network.dhcpd_enabled,
+        "dns_custom": network.dhcpd_dns_enabled,
+        "dns_servers": dns_servers,
+        "mdns_enabled": network.mdns_enabled,
+        "cellular_backup_enabled": network.lte_lan_enabled,
+    });
+
+    if out.is_json() {
+        out.print_data(&serde_json::to_string_pretty(&record)?);
+        return Ok(());
+    }
+
+    let name = record["name"].as_str().unwrap_or("-");
+    println!(
+        "{}",
+        if use_color() {
+            format!("{}", name.bold())
+        } else {
+            name.into()
+        }
+    );
+    for (label, value) in [
+        ("ID", record["id"].as_str().unwrap_or("-").to_string()),
+        (
+            "Purpose",
+            record["purpose"].as_str().unwrap_or("-").to_string(),
+        ),
+        (
+            "VLAN",
+            record["vlan_id"]
+                .as_u64()
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| "-".into()),
+        ),
+        (
+            "Subnet",
+            record["subnet"].as_str().unwrap_or("-").to_string(),
+        ),
+        (
+            "DHCP",
+            record["dhcp_enabled"]
+                .as_bool()
+                .unwrap_or(false)
+                .to_string(),
+        ),
+        ("DNS", dns_servers.join(", ")),
+        (
+            "mDNS",
+            record["mdns_enabled"]
+                .as_bool()
+                .unwrap_or(false)
+                .to_string(),
+        ),
+        (
+            "Cellular backup",
+            record["cellular_backup_enabled"]
+                .as_bool()
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| "-".into()),
+        ),
+    ] {
+        println!("  {label:<18} {value}");
+    }
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -294,6 +294,11 @@ enum ConfigCommand {
 enum NetworksCommand {
     /// List networks
     List,
+    /// Show network configuration by name or ID
+    Show {
+        /// Network name or controller ID
+        identifier: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1484,7 +1489,12 @@ async fn run() {
                 commands::devices::upgrade(&client, &mac, out).await
             }
         },
-        Command::Networks { .. } => commands::networks::list(&mut client, out).await,
+        Command::Networks { command } => match command.unwrap_or(NetworksCommand::List) {
+            NetworksCommand::List => commands::networks::list(&mut client, out).await,
+            NetworksCommand::Show { identifier } => {
+                commands::networks::show(&client, &identifier, out).await
+            }
+        },
         Command::Ports(cmd) => match cmd {
             PortsCommand::List {
                 mac,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -233,6 +233,26 @@ fn command_metadata() -> HashMap<&'static str, CommandMeta> {
 
     // networks / events / system
     m.insert("networks list", f(fields::NETWORKS_LIST, false, None));
+    m.insert(
+        "networks show",
+        f(
+            &[
+                ("id", "string"),
+                ("name", "string"),
+                ("purpose", "string"),
+                ("vlan_id", "integer"),
+                ("subnet", "string"),
+                ("enabled", "boolean"),
+                ("dhcp_enabled", "boolean"),
+                ("dns_custom", "boolean"),
+                ("dns_servers", "array"),
+                ("mdns_enabled", "boolean"),
+                ("cellular_backup_enabled", "boolean"),
+            ],
+            false,
+            Some("Uses the richer legacy network configuration endpoint and emits only typed, non-secret fields."),
+        ),
+    );
     m.insert("events list", f(fields::EVENTS_LIST, false, None));
     m.insert(
         "system health",

--- a/tests/mock_server.rs
+++ b/tests/mock_server.rs
@@ -544,6 +544,32 @@ mod client_api {
     }
 
     #[tokio::test]
+    async fn get_network_detail_matches_name_without_exposing_unknown_fields() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/proxy/network/api/s/default/rest/networkconf"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "meta": {"rc": "ok"},
+                "data": [{
+                    "_id": "net-1", "name": "IoT", "purpose": "corporate",
+                    "vlan": 20, "ip_subnet": "192.0.2.1/24", "enabled": true,
+                    "dhcpd_enabled": true, "dhcpd_dns_enabled": true,
+                    "dhcpd_dns_1": "192.0.2.53", "mdns_enabled": true,
+                    "lte_lan_enabled": false,
+                    "x_private_key": "must-never-be-deserialized"
+                }]
+            })))
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server).await;
+        let network = client.get_network_detail("iot").await.unwrap();
+        assert_eq!(network.id, "net-1");
+        assert_eq!(network.vlan, Some(20));
+        assert_eq!(network.lte_lan_enabled, Some(false));
+    }
+
+    #[tokio::test]
     async fn get_health_returns_subsystems() {
         let server = MockServer::start().await;
 
@@ -4799,6 +4825,31 @@ mod schema_contract {
         .await;
         let body = run_json(&server, &["networks", "list"]).await;
         assert_schema_matches("networks list", &body);
+    }
+
+    #[tokio::test]
+    async fn networks_show_json_matches_schema_and_omits_unknown_fields() {
+        let server = serving_legacy(
+            "rest/networkconf",
+            serde_json::json!([{
+                "_id": "net-1", "name": "LAN", "purpose": "corporate",
+                "vlan": 10, "ip_subnet": "192.0.2.1/24", "enabled": true,
+                "dhcpd_enabled": true, "dhcpd_dns_enabled": true,
+                "dhcpd_dns_1": "192.0.2.53", "dhcpd_dns_2": "192.0.2.54",
+                "mdns_enabled": true, "lte_lan_enabled": false,
+                "x_private_key": "must-not-appear",
+                "x_api_token": "must-not-appear-either"
+            }]),
+        )
+        .await;
+        let body = run_json(&server, &["networks", "show", "lan"]).await;
+        assert_schema_matches("networks show", &body);
+        let encoded = body.to_string();
+        assert!(!encoded.contains("must-not-appear"));
+        assert_eq!(
+            body["dns_servers"],
+            serde_json::json!(["192.0.2.53", "192.0.2.54"])
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Add `unifi networks show <name-or-id>` for inspecting a network configuration through the legacy controller API.

## Why

`networks list` does not expose operational settings such as DHCP DNS, mDNS, or cellular-backup eligibility. This provides a scriptable read-only view without requiring browser automation.

## Safety

The legacy endpoint may contain sensitive controller fields. The response is deserialized into a typed allowlist and the command emits only documented fields. Regression coverage injects secret-like unknown fields and verifies they never reach output.

## Checks

- `env -u UNIFI_API_KEY -u UNIFI_HOST make check`
- Live read-only validation against a UniFi controller
