### PR TITLE
feat: add firewall inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,13 @@ unifi networks list                         # List all networks
 unifi networks                              # Same thing
 ```
 
+### Firewall
+
+```bash
+unifi firewall rules                        # List firewall rules
+unifi firewall groups                       # List address and port groups
+```
+
 ### System
 
 ```bash

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -445,6 +445,14 @@ impl UnifiClient {
         .await
     }
 
+    pub async fn list_firewall_rules(&self) -> Result<Vec<FirewallRule>, ApiError> {
+        self.get_legacy("/rest/firewallrule").await
+    }
+
+    pub async fn list_firewall_groups(&self) -> Result<Vec<FirewallGroup>, ApiError> {
+        self.get_legacy("/rest/firewallgroup").await
+    }
+
     // Events
     //
     // Legacy `stat/event` was removed in UniFi Network 9+ (UniFi OS) and now

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -26,6 +26,34 @@ pub struct LegacyMeta {
     pub msg: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct FirewallRule {
+    #[serde(rename = "_id")]
+    pub id: String,
+    pub name: Option<String>,
+    #[serde(default)]
+    pub enabled: bool,
+    pub ruleset: Option<String>,
+    pub action: Option<String>,
+    pub protocol: Option<String>,
+    pub src_address: Option<String>,
+    pub dst_address: Option<String>,
+    pub dst_port: Option<String>,
+    pub rule_index: Option<u32>,
+    #[serde(default)]
+    pub logging: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FirewallGroup {
+    #[serde(rename = "_id")]
+    pub id: String,
+    pub name: Option<String>,
+    pub group_type: Option<String>,
+    #[serde(default)]
+    pub group_members: Vec<String>,
+}
+
 // Site
 #[derive(Debug, Deserialize)]
 pub struct Site {

--- a/src/commands/firewall.rs
+++ b/src/commands/firewall.rs
@@ -1,0 +1,74 @@
+use crate::api::UnifiClient;
+use crate::output::OutputConfig;
+
+pub async fn list_rules(
+    client: &UnifiClient,
+    out: OutputConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let rules = client.list_firewall_rules().await?;
+    let rows: Vec<_> = rules
+        .iter()
+        .map(|r| {
+            serde_json::json!({
+                "id": r.id, "name": r.name, "enabled": r.enabled, "ruleset": r.ruleset,
+                "action": r.action, "protocol": r.protocol, "source": r.src_address,
+                "destination": r.dst_address, "destination_port": r.dst_port,
+                "index": r.rule_index, "logging": r.logging,
+            })
+        })
+        .collect();
+    if out.is_json() {
+        out.print_data(&serde_json::to_string_pretty(&rows)?);
+    } else {
+        println!(
+            "{:<5} {:<8} {:<16} {:<8} Name",
+            "Index", "Enabled", "Ruleset", "Action"
+        );
+        println!("{}", "-".repeat(78));
+        for r in &rules {
+            println!(
+                "{:<5} {:<8} {:<16} {:<8} {}",
+                r.rule_index
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| "-".into()),
+                if r.enabled { "yes" } else { "no" },
+                r.ruleset.as_deref().unwrap_or("-"),
+                r.action.as_deref().unwrap_or("-"),
+                r.name.as_deref().unwrap_or("-")
+            );
+        }
+    }
+    out.print_message(&format!("\n{} firewall rules", rules.len()));
+    Ok(())
+}
+
+pub async fn list_groups(
+    client: &UnifiClient,
+    out: OutputConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let groups = client.list_firewall_groups().await?;
+    let rows: Vec<_> = groups
+        .iter()
+        .map(|g| {
+            serde_json::json!({
+                "id": g.id, "name": g.name, "type": g.group_type, "members": g.group_members,
+            })
+        })
+        .collect();
+    if out.is_json() {
+        out.print_data(&serde_json::to_string_pretty(&rows)?);
+    } else {
+        println!("{:<28} {:<16} Members", "Name", "Type");
+        println!("{}", "-".repeat(78));
+        for g in &groups {
+            println!(
+                "{:<28} {:<16} {}",
+                g.name.as_deref().unwrap_or("-"),
+                g.group_type.as_deref().unwrap_or("-"),
+                g.group_members.join(", ")
+            );
+        }
+    }
+    out.print_message(&format!("\n{} firewall groups", groups.len()));
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod clients;
 pub mod devices;
 pub mod events;
+pub mod firewall;
 pub mod networks;
 pub mod ports;
 pub mod protect;

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,10 @@ enum Command {
         command: Option<NetworksCommand>,
     },
 
+    /// Inspect firewall rules and groups
+    #[command(subcommand)]
+    Firewall(FirewallCommand),
+
     /// Inspect and manage switch ports
     #[command(subcommand)]
     Ports(PortsCommand),
@@ -294,6 +298,14 @@ enum ConfigCommand {
 enum NetworksCommand {
     /// List networks
     List,
+}
+
+#[derive(Subcommand)]
+enum FirewallCommand {
+    /// List firewall rules
+    Rules,
+    /// List firewall address and port groups
+    Groups,
 }
 
 #[derive(Subcommand)]
@@ -1485,6 +1497,10 @@ async fn run() {
             }
         },
         Command::Networks { .. } => commands::networks::list(&mut client, out).await,
+        Command::Firewall(cmd) => match cmd {
+            FirewallCommand::Rules => commands::firewall::list_rules(&client, out).await,
+            FirewallCommand::Groups => commands::firewall::list_groups(&client, out).await,
+        },
         Command::Ports(cmd) => match cmd {
             PortsCommand::List {
                 mac,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -233,6 +233,39 @@ fn command_metadata() -> HashMap<&'static str, CommandMeta> {
 
     // networks / events / system
     m.insert("networks list", f(fields::NETWORKS_LIST, false, None));
+    m.insert(
+        "firewall rules",
+        f(
+            &[
+                ("id", "string"),
+                ("name", "string"),
+                ("enabled", "boolean"),
+                ("ruleset", "string"),
+                ("action", "string"),
+                ("protocol", "string"),
+                ("source", "string"),
+                ("destination", "string"),
+                ("destination_port", "string"),
+                ("index", "integer"),
+                ("logging", "boolean"),
+            ],
+            false,
+            None,
+        ),
+    );
+    m.insert(
+        "firewall groups",
+        f(
+            &[
+                ("id", "string"),
+                ("name", "string"),
+                ("type", "string"),
+                ("members", "array"),
+            ],
+            false,
+            None,
+        ),
+    );
     m.insert("events list", f(fields::EVENTS_LIST, false, None));
     m.insert(
         "system health",

--- a/tests/mock_server.rs
+++ b/tests/mock_server.rs
@@ -544,6 +544,35 @@ mod client_api {
     }
 
     #[tokio::test]
+    async fn list_firewall_inventory_uses_typed_records() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/proxy/network/api/s/default/rest/firewallrule"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "meta": {"rc": "ok"},
+                "data": [{"_id": "rule-1", "name": "Allow DNS", "enabled": true,
+                    "ruleset": "LAN_IN", "action": "accept", "protocol": "tcp_udp",
+                    "dst_port": "53", "x_private_key": "must-not-escape"}]
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/proxy/network/api/s/default/rest/firewallgroup"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "meta": {"rc": "ok"},
+                "data": [{"_id": "group-1", "name": "DNS", "group_type": "address-group",
+                    "group_members": ["192.0.2.53"], "x_api_token": "must-not-escape"}]
+            })))
+            .mount(&server)
+            .await;
+        let client = mock_client(&server).await;
+        let rules = client.list_firewall_rules().await.unwrap();
+        let groups = client.list_firewall_groups().await.unwrap();
+        assert_eq!(rules[0].dst_port.as_deref(), Some("53"));
+        assert_eq!(groups[0].group_members, ["192.0.2.53"]);
+    }
+
+    #[tokio::test]
     async fn get_health_returns_subsystems() {
         let server = MockServer::start().await;
 
@@ -4852,5 +4881,35 @@ mod schema_contract {
         .await;
         let body = run_json(&server, &["system", "health"]).await;
         assert_schema_matches("system health", &body);
+    }
+
+    #[tokio::test]
+    async fn firewall_json_matches_schema_and_omits_unknown_fields() {
+        let server = MockServer::start().await;
+        mount_legacy(
+            &server,
+            "rest/firewallrule",
+            serde_json::json!([{
+                "_id": "rule-1", "name": "Allow DNS", "enabled": true,
+                "ruleset": "LAN_IN", "action": "accept", "protocol": "tcp_udp",
+                "dst_port": "53", "rule_index": 10, "x_private_key": "must-not-escape"
+            }]),
+        )
+        .await;
+        mount_legacy(
+            &server,
+            "rest/firewallgroup",
+            serde_json::json!([{
+                "_id": "group-1", "name": "DNS", "group_type": "address-group",
+                "group_members": ["192.0.2.53"], "x_api_token": "must-not-escape"
+            }]),
+        )
+        .await;
+        let rules = run_json(&server, &["firewall", "rules"]).await;
+        let groups = run_json(&server, &["firewall", "groups"]).await;
+        assert_schema_matches("firewall rules", &rules);
+        assert_schema_matches("firewall groups", &groups);
+        let rendered = format!("{rules}{groups}");
+        assert!(!rendered.contains("must-not-escape"));
     }
 }


### PR DESCRIPTION
## What

Add read-only `unifi firewall rules` and `unifi firewall groups` commands with text, JSON, and schema support.

## Why

Firewall policy currently requires controller UI inspection. These commands make policy audits and automation possible through the CLI.

## Safety

Both legacy resources are decoded into narrow typed records. Unknown vendor fields are discarded; regression fixtures inject secret-like fields and verify they never appear in command output.

## Checks

- `env -u UNIFI_API_KEY -u UNIFI_HOST make check`
- Live read-only validation against a UniFi controller (12 rules, 11 groups)
